### PR TITLE
refactor: add pointer-events-none class to BlurImage component

### DIFF
--- a/src/components/BlurImage.tsx
+++ b/src/components/BlurImage.tsx
@@ -15,7 +15,7 @@ export default function BlurImage({ className = '', ...rest} : TProps) {
     const [isLoading, setLoading] = useState(true);
 
     const imageClasses = clsx({
-        'duration-700 ease-in-out group-hover:opacity-75 object-cover': true,
+        'duration-700 ease-in-out group-hover:opacity-75 object-cover pointer-events-none': true,
         'scale-110 blur-2xl grayscale': isLoading,
         'scale-100 blur-0 grayscale-0': !isLoading,
         [className]: !!className


### PR DESCRIPTION
This pull request includes a small change to the `BlurImage` component in the `src/components/BlurImage.tsx` file. The change adds the `pointer-events-none` class to the `imageClasses` variable to prevent pointer events on the image while it is loading.

* [`src/components/BlurImage.tsx`](diffhunk://#diff-5d995a60355211ff5d16b0f358a4a1db8549eda45c2da319846af115c794a023L18-R18): Added `pointer-events-none` to the `imageClasses` variable to prevent pointer events while the image is loading.