### PR TITLE
Fix/update schema for project images

### DIFF
--- a/prisma/migrations/20250211160254_make_images_field_optional_and_set_a_new_default_value/migration.sql
+++ b/prisma/migrations/20250211160254_make_images_field_optional_and_set_a_new_default_value/migration.sql
@@ -1,0 +1,3 @@
+-- AlterTable
+ALTER TABLE "Project" ALTER COLUMN "images" DROP NOT NULL,
+ALTER COLUMN "images" SET DEFAULT '[]';

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -32,7 +32,7 @@ model Project {
   id             Int      @id @unique @default(autoincrement())
   createdAt      DateTime @default(now())
   period         String   @default("2000")
-  images         String   @default("https://earnionc.sirv.com/portfolio-felix/Projects/sp1.png, https://earnionc.sirv.com/portfolio-felix/Projects/sp2.png, https://earnionc.sirv.com/portfolio-felix/Projects/sp3.png")
+  images         String?   @default("[]")
   enterpriseName String
   logo           String
   description    String

--- a/src/components/ProjectResume.tsx
+++ b/src/components/ProjectResume.tsx
@@ -17,7 +17,7 @@ export const ProjectResume = ({
 }: Project) => {
     const [isOpened, setIsOpened] = useState(false);
     const stackArray = splitString(stack);
-    const imagesArray = splitString(images);
+    const imagesArray = images?.length ? splitString(images): [];
     const isPOC = status === ProjectStatus.poc;
 
     return (

--- a/src/models/types.ts
+++ b/src/models/types.ts
@@ -37,7 +37,7 @@ export type Project = {
     logo: string,
     contributions: string,
     stack: string,
-    images: string,
+    images?: string,
     enterpriseName: string,
     description: string,
     period: string,


### PR DESCRIPTION
This pull request includes changes to make the `images` field in the `Project` model optional and set a new default value. The changes affect the database schema, the Prisma schema, and related TypeScript files.

Database schema changes:

* [`prisma/migrations/20250211160254_make_images_field_optional_and_set_a_new_default_value/migration.sql`](diffhunk://#diff-637243f811b9aba0171c2b85f7e01fec79728508aa373a649c5e58f6dff43493R1-R3): Altered the `Project` table to drop the `NOT NULL` constraint on the `images` column and set its default value to an empty array (`'[]'`).

Prisma schema changes:

* [`prisma/schema.prisma`](diffhunk://#diff-5b443964f4f3a611682db8f7e02177b0a8c632b2039e2bd5e4dd7347815c565cL35-R35): Updated the `images` field in the `Project` model to be optional (`String?`) and changed its default value to an empty array (`'[]'`).

TypeScript updates:

* [`src/components/ProjectResume.tsx`](diffhunk://#diff-dc24331e1445ac420334fc0c17f4dd551e3cdaedf803d65d74da7466e9b4f586L20-R20): Modified the `imagesArray` initialization to handle the optional `images` field, setting it to an empty array if `images` is undefined or empty.
* [`src/models/types.ts`](diffhunk://#diff-f851ca827241622b321c32db1d55519096d871f3ecaff8e4f081a16249c79e85L40-R40): Updated the `Project` type definition to make the `images` field optional (`images?: string`).